### PR TITLE
Add DNS record management command with export functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
       <version>${lanterna.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>dnsjava</groupId>
+      <artifactId>dnsjava</artifactId>
+      <version>${dnsjava.version}</version>
+    </dependency>
+
   </dependencies>
 
   <properties>
@@ -121,6 +127,7 @@
     <lombok.version>1.18.40</lombok.version>
     <lanterna.version>3.1.3</lanterna.version>
     <asciitable.version>0.3.2</asciitable.version>
+    <dnsjava.version>3.6.3</dnsjava.version>
   </properties>
 
   <build>

--- a/src/main/java/com/trinhminhtriet/devpilot/command/DnsRecordCommand.java
+++ b/src/main/java/com/trinhminhtriet/devpilot/command/DnsRecordCommand.java
@@ -1,0 +1,66 @@
+package com.trinhminhtriet.devpilot.command;
+
+import com.trinhminhtriet.devpilot.service.DnsRecordService;
+import com.trinhminhtriet.devpilot.service.impl.DnsRecordServiceImpl;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.List;
+import org.xbill.DNS.Record;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
+
+@Command(name = "dns", description = "Print and export DNS records of a domain.")
+public class DnsRecordCommand implements Runnable {
+
+  @Parameters(index = "0", description = "Domain to query")
+  private String domain;
+
+  @Option(names = {"-e", "--export"}, description = "Export type: csv or xlsx")
+  private String exportType;
+
+  @Option(names = {"-o", "--output"}, description = "Output file path")
+  private String exportPath;
+
+  private final DnsRecordService dnsRecordService = new DnsRecordServiceImpl();
+
+  @Override
+  public void run() {
+    try {
+      List<Record> records = dnsRecordService.getAllRecords(domain);
+      if (exportType == null || exportType.isEmpty()) {
+        for (Record record : records) {
+          System.out.println(record);
+        }
+      } else if (exportType.equalsIgnoreCase("csv")) {
+        exportToCsv(records, exportPath);
+        System.out.println("Exported DNS records to CSV: " + exportPath);
+      } else if (exportType.equalsIgnoreCase("xlsx")) {
+        exportToExcel(records, exportPath);
+      } else {
+        throw new IllegalArgumentException("Unsupported export type: " + exportType);
+      }
+    } catch (Exception e) {
+      System.err.println("Error: " + e.getMessage());
+      e.printStackTrace();
+    }
+  }
+
+  private void exportToCsv(List<Record> records, String path) throws IOException {
+    try (FileWriter writer = new FileWriter(path)) {
+      writer.write("Type,Name,TTL,Data\n");
+      for (Record record : records) {
+        writer.write(String.format("%s,%s,%d,%s\n",
+            record.getType(),
+            record.getName(),
+            record.getTTL(),
+            record.rdataToString()));
+      }
+    }
+  }
+
+  private void exportToExcel(List<Record> records, String path) throws IOException {
+    // TODO: Implement Excel export using Apache POI or similar library
+    throw new UnsupportedOperationException("Excel export not implemented yet.");
+  }
+}

--- a/src/main/java/com/trinhminhtriet/devpilot/command/RootCommand.java
+++ b/src/main/java/com/trinhminhtriet/devpilot/command/RootCommand.java
@@ -36,6 +36,7 @@ import picocli.CommandLine.Command;
         EnvCommand.class,
         ProjectCommand.class,
         AutoCompletionCommand.class,
+        DnsRecordCommand.class,
         MfaCommand.class
     }
 )

--- a/src/main/java/com/trinhminhtriet/devpilot/service/DnsRecordService.java
+++ b/src/main/java/com/trinhminhtriet/devpilot/service/DnsRecordService.java
@@ -1,0 +1,9 @@
+package com.trinhminhtriet.devpilot.service;
+
+import java.util.List;
+import org.xbill.DNS.Record;
+
+public interface DnsRecordService {
+
+  List<Record> getAllRecords(String domain) throws Exception;
+}

--- a/src/main/java/com/trinhminhtriet/devpilot/service/impl/DnsRecordServiceImpl.java
+++ b/src/main/java/com/trinhminhtriet/devpilot/service/impl/DnsRecordServiceImpl.java
@@ -1,0 +1,26 @@
+package com.trinhminhtriet.devpilot.service.impl;
+
+import com.trinhminhtriet.devpilot.service.DnsRecordService;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.xbill.DNS.Lookup;
+import org.xbill.DNS.Type;
+import org.xbill.DNS.Record;
+
+public class DnsRecordServiceImpl implements DnsRecordService {
+
+  @Override
+  public List<Record> getAllRecords(String domain) throws Exception {
+    List<Record> records = new ArrayList<>();
+    int[] types = {Type.A, Type.AAAA, Type.CNAME, Type.MX, Type.NS, Type.SOA, Type.TXT, Type.SRV, Type.PTR};
+    for (int type : types) {
+      Lookup lookup = new Lookup(domain, type);
+      Record[] recs = lookup.run();
+      if (recs != null) {
+        records.addAll(Arrays.asList(recs));
+      }
+    }
+    return records;
+  }
+}

--- a/src/main/resources/templates/typescript/gitattributes.ftl
+++ b/src/main/resources/templates/typescript/gitattributes.ftl
@@ -1,6 +1,7 @@
+* text=auto eol=lf
+
 # TypeScript .gitattributes
 *.ts linguist-language=TypeScript
 *.js linguist-language=JavaScript
 package.json linguist-language=JSON
-* text=auto
 *.md text


### PR DESCRIPTION
Introduce a command for managing DNS records, allowing users to print and export records in CSV format. Update the `.gitattributes` file to enforce LF line endings for better text handling.